### PR TITLE
chore: remove persist credentials for default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          persist-credentials: false
           fetch-depth: 0
       - name: Release
         uses: cycjimmy/semantic-release-action@v3.4.2


### PR DESCRIPTION
## Pull Request Description

**Description:**

**Related Issue:**

## Checklist

- [x] I have added the [appropriate prefix ](https://github.com/FidelusAleksander/gh-action-regex/blob/master/CONTRIBUTING.md#semantic-pull-requests) to the pull request title
- [x] The CI tests are passing for this pull request.
- [x] The `pre-commit run -a` hooks are passing for this pull request.
